### PR TITLE
Textual changes

### DIFF
--- a/src/cljs/ethlance/pages/about_page.cljs
+++ b/src/cljs/ethlance/pages/about_page.cljs
@@ -12,16 +12,16 @@
       [misc/center-layout
        [paper
         [:h2 "About Us"]
-        [:p "Ethlance is a first of its kind platform for job market, built entirely on blockchain and using only cryptocurrency
-    for payments. Thanks to those technologies, platform can sustainably run with 0% service fees.
-    Ethlance will never take cut from transactions between freelancers and employers."]
-        [:p "We're running on public " [link "https://ethereum.org/" "Ethereum"] " blockchain with front-end source
-    files written in " [link "https://clojurescript.org/" "Clojurescript"] " and served from decentralised file storage "
+        [:p "Ethlance is a first of its kind job market platform, built entirely on blockchain and using only cryptocurrency
+    for payments. Thanks to those technologies, the platform can sustainably run with 0% service fees.
+    Ethlance will never take a cut from transactions between freelancers and employers."]
+        [:p "We're running on the public " [link "https://ethereum.org/" "Ethereum"] " blockchain with our front-end source
+    files written in " [link "https://clojurescript.org/" "ClojureScript"] " and served via decentralised file storage using "
          [link "https://ipfs.io/" "IPFS"] ". Ethlance is completely open-source and you can find its
     code on " [link "https://github.com/madvas/ethlance" "github.com/madvas/ethlance"] ". If you found a bug,
-    please don't hesitate to open an issue there."]
-        [:p "If you're unsure how to use Ethereum, please see " [a {:route :how-it-works} "How it works"] " page"]
-        [:p "Ethlance backend logic consists of " (count @eth-contracts) " smart-contracts, deployed on following addresses:"]
+    please don't hesitate " [link "to open an issue there" "https://github.com/madvas/ethlance/issues/new"] "."]
+        [:p "If you're unsure how to use Ethereum, please see the " [a {:route :how-it-works} "How it works"] " page"]
+        [:p "The Ethlance backend logic consists of " (count @eth-contracts) " smart-contracts, deployed on the following addresses:"]
         [:ul
          (for [[key {:keys [:github-page :name :address]}] @eth-contracts]
            [:li

--- a/src/cljs/ethlance/pages/contract_detail_page.cljs
+++ b/src/cljs/ethlance/pages/contract_detail_page.cljs
@@ -238,7 +238,7 @@
           [:h2 "Cancel Contract"]
           [:div {:style (merge styles/fade-text styles/margin-top-gutter-less)}
            "You can cancel this contract in case you decided for another job or you can't start work for other reasons."
-           [:br] "After you create at least 1 invoice for this contract, this option won't be available anymore."]
+           [:br] "After you create at least one invoice for this contract, this option will be unavailable."]
           [misc/textarea
            {:floating-label-text "Message"
             :form-key :form.contract/cancel-contract
@@ -289,8 +289,8 @@
           (when (= status 3)
             [:div {:style styles/form-item}
              (if (and (zero? invoices-count) employer?)
-               "You will be able to leave feedback only after freelancer sends you at least 1 invoice"
-               "Note, by leaving feedback you will end this contract. That means no more invoices can be sent.")])
+               "You will be able to leave feedback after the freelancer sends you at least one invoice."
+               "Note that by leaving feedback you will end this contract, which means no more invoices can be sent.")])
           [misc/send-button
            {:disabled (or loading?
                           (boolean (seq errors))

--- a/src/cljs/ethlance/pages/employer_detail_page.cljs
+++ b/src/cljs/ethlance/pages/employer_detail_page.cljs
@@ -65,7 +65,7 @@
               [employer-info]
               [row-plain
                {:center "xs"}
-               "This user is not registered as a employer"])])]))))
+               "This user is not registered as an employer"])])]))))
 
 (defn employer-jobs []
   (let [xs-width? (subscribe [:window/xs-width?])

--- a/src/cljs/ethlance/pages/freelancer_detail_page.cljs
+++ b/src/cljs/ethlance/pages/freelancer_detail_page.cljs
@@ -41,7 +41,7 @@
          [skills-chips
           {:selected-skills skills
            :always-show-all? true}]
-         [misc/subheader "Interested in categories"]
+         [misc/subheader "Interested in Categories"]
          [misc/call-on-change
           {:load-on-mount? true
            :args {id (select-keys user [:freelancer/categories-count])}

--- a/src/cljs/ethlance/pages/home_page.cljs
+++ b/src/cljs/ethlance/pages/home_page.cljs
@@ -98,7 +98,8 @@
     {:xs 10 :sm 7 :md 5 :lg 4
      :style styles/text-left}
     [:h1.black "We take no cut!"]
-    [:h3.black "Ethlance doesn’t take any percentage of your earned Ether. Amount of Ether employer pays is exactly what freelancer gets."]]
+    [:h3.black "Ethlance doesn’t take a percentage of your earned Ether.
+    The amount of Ether the employer pays is the amount the freelancer gets."]]
    [col
     {:xs 5 :sm 3 :md 3 :lg 2}
     [:img
@@ -118,7 +119,7 @@
     {:xs 8 :sm 6 :sm-offset 1 :md 5
      :style styles/text-left}
     [:h1.black "It’s all on blockchain!"]
-    [:h3.black "Ethlance database is distributed on Ethereum public blockchain and source files on IPFS.
+    [:h3.black "The Ethlance database is distributed on the Ethereum public blockchain and the source files are on IPFS.
     This makes it accessible to everyone forever, without any central authority having control over it."]]])
 
 (defn feature-no-restrictions []
@@ -129,7 +130,8 @@
     {:xs 8 :sm 8 :md 4
      :style styles/text-left}
     [:h1.black "No artificial restrictions!"]
-    [:h3.black "Everybody can apply for, or create unlimited number of jobs. All that is needed, is to pay Ethereum gas fees associated with these operations."]]
+    [:h3.black "Everybody can apply for, or create, an unlimited number of jobs.
+    All that is needed is to pay Ethereum gas fees associated with these operations."]]
    [col
     {:xs 10 :sm 8 :md 6 :lg 5}
     [:img

--- a/src/cljs/ethlance/pages/how_it_works_page.cljs
+++ b/src/cljs/ethlance/pages/how_it_works_page.cljs
@@ -17,9 +17,9 @@
   [misc/center-layout
    [paper
     [:h2 "How it works?"]
-    [:p "Ethlance is running on " [link "https://ethereum.org/" "Ethereum"] " public blockchain,
-    therefore you'll need " [link "https://metamask.io/" "MetaMask"] " browser extension to be able to make
-    changes into a blockchain. See our video tutorials, where everything is clearly explained!"]
+    [:p "Ethlance is running on the " [link "https://ethereum.org/" "Ethereum"] " public blockchain,
+    therefore you'll need the " [link "https://metamask.io/" "MetaMask"] " browser extension to be able to make
+    changes into the blockchain. See our video tutorials, where everything is clearly explained!"]
     [video
      {:title "Installing MetaMask Chrome Extension"
       :src "https://www.youtube.com/embed/gUZ_XT0a9_U?list=PL4rQUoitSeEH8ybx-yM1ocuvF9OvSVkU4"}]
@@ -43,26 +43,26 @@
      "Frequently Asked Questions"]
     [:h3.bolder "How do I get Ether (Ξ) cryptocurrency?"]
     [:p "Obtaining Ether is very similar to obtaining " [link "https://en.wikipedia.org/wiki/Bitcoin" "Bitcoin"]
-     ". Most common way is to register at one of worldwide
-    cryptocurrency exchanges and they will exchange your fiat currency into cryptocurrency. Note, that exchange from
-    Bitcoin into Ether can be done directly in " [link "https://metamask.io/" "MetaMask"] " or "
+     ". The most common way is to register at one of the worldwide
+    cryptocurrency exchanges that exchange fiat currency for cryptocurrency. Note that exchange from
+    Bitcoin to Ether can be done directly in " [link "https://metamask.io/" "MetaMask"] " or "
      [link "https://github.com/ethereum/mist" "Mist browser"] "."]
     [:h3.bolder "Why do I have to pay Ethereum gas fees?"]
-    [:p "Everytime you'll want to change something in Ethlance database you'll be asked to pay small fee (usually couple of cents)
-     called \"gas fees\". These money are used to compensate for electricity costs of computers running Ethereum blockchain.
-     Thanks to this, Ethlance doesn't need to rent servers and therefore keep service fees as low as 0%! It it also
-     great protection against spam. " [:u "Note, money from gas fees are by no means profit of Ethlance"] "."]
-    [:h3.bolder "What if employer didn't pay for my work?"]
+    [:p "Every time you'll want to change something in the Ethlance database you'll be asked to pay a small fee (usually a couple of cents)
+     called \"gas fees\". This fee is used to compensate for the electricity costs of the computers running the Ethereum blockchain.
+     Thanks to this, Ethlance doesn't need to rent servers and therefore keeps service fees as low as 0%! This fee is a
+     great protection against spam. " [:u "Gas fees are by no means profit of Ethlance"] "."]
+    [:h3.bolder "What if an employer didn't pay for my work?"]
     [:p "Ethlance holds no responsibility for resolving disputes between freelancers and employers. " [:br]
-     "These are some of our advices on how to prevent such situations:"]
+     "These are some of our guidelines to prevent such situations:"]
     [:ul
      [:li "Read all past feedback of a freelancer/employer."]
-     [:li "Send invoices to an employer frequently. Don't continue with work until previous invoice is paid."]
-     [:li "See balance on his/her wallet, whether there is enough money to pay you."]
+     [:li "Send invoices to an employer frequently. Don't continue with your work until a previous invoice is paid."]
+     [:li "Check the balance on his or her wallet whether there's enough money to pay you."]
      [:li "Establish good communication with a freelancer/employer."]]
     [:h3.bolder "Why does it take so long after I submit a form?"]
-    [:p "Ethereum average block time is around 15 seconds. That means, in practice you'll wait around 15-30
-    seconds until you get confirmation. However, occasionally this can be even several minutes. While your
-     form is being submitted into blockchain, you can freely browse website, you will always be notified
-     when your data has been processed. Avoid refreshing page."]
+    [:p "The average block time on Ethereum is around 15 seconds. In practice this means you'll wait around 15 to 30
+    seconds until you get a confirmation. Occasionally, however, the wait time can be several minutes. Note that while your
+     form is submitted into the blockchain you can freely browse the website. You will always be notified
+     when your data has been processed. Avoid refreshing the page."]
     [a {:route :about} "About Us"]]])

--- a/src/cljs/ethlance/pages/invoice_create_page.cljs
+++ b/src/cljs/ethlance/pages/invoice_create_page.cljs
@@ -84,7 +84,7 @@
            :value worked-minutes
            :max 59
            :error-text (when (< 59 worked-minutes)
-                         "Choose value between 0 and 59")}]
+                         "Choose a value between 0 and 59")}]
          (when (pos? contract-id)
            [misc/ether-field-with-currency
             {:floating-label-text (cond

--- a/src/cljs/ethlance/pages/invoice_detail_page.cljs
+++ b/src/cljs/ethlance/pages/invoice_detail_page.cljs
@@ -81,11 +81,11 @@
             (when tampered?
               [:div
                {:style {:color styles/accent1-color}}
-               "Looks like this conversion rate is invalid. Correct should be "
+               "Looks like this conversion rate is invalid. The correct rate should be "
                [misc/conversion-rate
                 {:currency reference-currency
                  :value correct-rate}]
-               ". Please report this to Ethlance team"]))])
+               ". Please report this to the Ethlance team"]))])
        (when (and (pos? reference-currency)
                   (= payment-type 1))
          [line (str "Amount in " (u/currency-full-name reference-currency))
@@ -195,6 +195,6 @@
                       :on-touch-tap #(dispatch [:contract.invoice/pay-invoice {:invoice/id id} 0])}]]
                    [:small
                     (case (:job/status job)
-                      5 "This invoice can't be paid, because you are in process of refunding sponsors"
+                      5 "This invoice can't be paid, because you are in the process of refunding sponsors"
                       6 "This invoice can't be paid, because you already refunded sponsors"
                       "")]))]])]]]))))

--- a/src/cljs/ethlance/pages/job_detail_page.cljs
+++ b/src/cljs/ethlance/pages/job_detail_page.cljs
@@ -150,7 +150,7 @@
              (when (and (not more-than-min-amount?) valid-amount?)
                [:small
                 {:style {:color styles/accent1-color}}
-                "Min sponsorship amount is " min-ether-amount " " (u/currency-full-name 0)])
+                "Min. sponsorship amount is " min-ether-amount " " (u/currency-full-name 0)])
              [misc/send-button
               {:disabled (or loading? (boolean (seq errors)) (not more-than-min-amount?))
                :on-touch-tap #(dispatch [:contract.sponsor/add-job-sponsorship
@@ -290,7 +290,7 @@
                                   allowed-users])
                        (when (= status 4)
                          (dispatch [:contract.views/load-job-approvals {:job/id id}])))}
-         [misc/subheader "Accounts allowed to spend sponsorships"]
+         [misc/subheader "Accounts Allowed for Sponsorships"]
          (doall
            (for [allowed-user allowed-users]
              (let [{:keys [:user/name :user/freelancer? :user/gravatar :user/id]} @(subscribe [:user/by-id allowed-user])

--- a/src/cljs/ethlance/pages/search_freelancers_page.cljs
+++ b/src/cljs/ethlance/pages/search_freelancers_page.cljs
@@ -66,7 +66,7 @@
                           (dispatch [:form.search/set-value :search/hourly-rate-currency currency])
                           (dispatch [:selected-currency/set currency]))}}]
           [misc/text-field-base
-           {:floating-label-text "Min. Number of Feedbacks"
+           {:floating-label-text "Min. Number of Ratings"
             :type :number
             :value min-freelancer-ratings-count
             :full-width true
@@ -179,7 +179,7 @@
     {:selected-skills-subscribe [:form/search-freelancer-skills]
      :selected-skills-or-subscribe [:form/search-freelancer-skills-or]
      :open-subscribe [:db/search-freelancers-skills-open?]
-     :skills-hint-text "Type skills you want a freelancer to have"
+     :skills-hint-text "Type of skills you want a freelancer to have"
      :skills-and-hint-text "Freelancers have all of entered skills"
      :skills-or-hint-text "Freelancers have at least one of entered skills"
      :skills-and-floating-label-text "All of skills are required"

--- a/src/cljs/ethlance/pages/search_jobs_page.cljs
+++ b/src/cljs/ethlance/pages/search_jobs_page.cljs
@@ -73,7 +73,7 @@
                           (dispatch [:form.search/set-value :search/min-budget-currency currency])
                           (dispatch [:selected-currency/set currency]))}}]
           [misc/text-field-base
-           {:floating-label-text "Min. Employer Feedbacks"
+           {:floating-label-text "Min. Employer Ratings"
             :floating-label-fixed true
             :type :number
             :value min-employer-ratings-count

--- a/src/cljs/ethlance/pages/skills_create_page.cljs
+++ b/src/cljs/ethlance/pages/skills_create_page.cljs
@@ -66,13 +66,13 @@
                                       (remove-error :max-skills-create-at-once)))))
            :error-text (cond
                          (contains? errors :not-alphanumeric)
-                         "You can use only alphanumeric characters"
+                         "You can only use alphanumeric characters"
 
                          (contains? errors :max-skill-name-length)
                          "Maximum length is 32 characters"
 
                          (contains? errors :skill-already-exists)
-                         "Such skill already exists"
+                         "This skill already exists"
 
                          (contains? errors :max-skills-create-at-once)
                          (gstring/format "You can add max %s skills at once" max-skills-create-at-once)

--- a/src/cljs/ethlance/pages/user_edit_page.cljs
+++ b/src/cljs/ethlance/pages/user_edit_page.cljs
@@ -38,12 +38,12 @@
 
 (def notifications
   [[:user.notif/disabled-on-message-added? "When I receive message"]
-   [:user.notif/disabled-on-job-invitation-added? "When I get job invitation" :user/freelancer?]
+   [:user.notif/disabled-on-job-invitation-added? "When I get a job invitation" :user/freelancer?]
    [:user.notif/disabled-on-job-contract-added? "When I get hired" :user/freelancer?]
    [:user.notif/disabled-on-invoice-paid? "When my invoice is paid" :user/freelancer?]
    [:user.notif/disabled-on-job-proposal-added? "When my job receives a job proposal" :user/employer?]
-   [:user.notif/disabled-on-invoice-added? "When I receive invoice to pay" :user/employer?]
-   [:user.notif/disabled-on-job-sponsorship-added? "When my job receives sponsorship or I get refunded"]
+   [:user.notif/disabled-on-invoice-added? "When I receive an invoice to pay" :user/employer?]
+   [:user.notif/disabled-on-job-sponsorship-added? "When my job receives a sponsorship or I get refunded"]
    [:user.notif/disabled-on-job-contract-feedback-added? "When I receive feedback"]
    [:user.notif/disabled-newsletter? "Ethlance news & announcements (occasional)"]])
 


### PR DESCRIPTION
I read to the texts in Ethlance and fixed some minor mistakes I saw.

- Fix some spelling mistakes (change or add articles like "a", "an" and
  "the").
  Note: when there's referred to blockchain technology in general I use
  "blockchain" without an article in front (e.g., "blockchain is
  decentralized"), but when referring to a specific blockchain I put an
  article in front of it (e.g., "the Ethereum blockchain").
- Use capitalization in all titles and subtitles consistently.
- Spell out numbers ("one") when not referring to money or percentages.
- Feedback is uncountable (feedbacks does not exist), changed to
  ratings.
- Use which instead of that for non-restrictive clause.
- Add link to open new issue.