### PR TITLE
Emacs startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ lein repl
 (figwheel-sidecar.repl-api/start-figwheel! (figwheel-sidecar.config/fetch-config))
 (figwheel-sidecar.repl-api/cljs-repl)
 ```
+
+See `ethlance.el` on how to run the above commands in Emacs via `ethlance-jack-in` and `ethlance-start`.
+
 Make sure in [ethlance.db/default-db](https://github.com/madvas/ethlance/blob/master/src/cljs/ethlance/db.cljs) you have following configuration:
 ```clojure
 :load-node-addresses? true

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Repository for [ethlance.com](http://ethlance.com) 
 
-Ethlance is first job market platform written in [Clojurescript](https://clojurescript.org/) and [Solidity](https://solidity.readthedocs.io/en/develop/) working completely on [Ethereum](https://ethereum.org/) blockchain with 0% service fees.
+Ethlance is the first job market platform written in [ClojureScript](https://clojurescript.org/) and [Solidity](https://solidity.readthedocs.io/en/develop/) working completely on the [Ethereum](https://ethereum.org/) blockchain with 0% service fees.
 
-Ethereum Smart Contracts are at `/resources/public/contracts/src`
+Ethereum Smart Contracts are at `/resources/public/contracts/src`.
 
 # Using Ethlance
 
@@ -18,14 +18,14 @@ Ethereum Smart Contracts are at `/resources/public/contracts/src`
 
 1. Download the [Mist Browser](https://github.com/ethereum/mist)
 2. Wait for blockchain to download
-3. Fund with ether
+3. Fund with Ether
 4. Go on [Ethlance](http://ethlance.com/)
 
 # Running on localhost
 
-Following instructions assume you're familiar with [Clojure](https://clojure.org/) language and have [lein](https://leiningen.org/) installed on your machine.
+Following instructions assume you're familiar with the [Clojure](https://clojure.org/) programming language and have [lein](https://leiningen.org/) installed on your machine.
 
-To start autocompile smart contracts (requires [solc](https://github.com/ethereum/solidity) installed):
+To start autocompiling smart contracts (requires [solc](https://github.com/ethereum/solidity) installed):
 ```bash
 lein auto compile-solidity
 ```
@@ -44,19 +44,20 @@ lein repl
 
 See `ethlance.el` on how to run the above commands in Emacs via `ethlance-jack-in` and `ethlance-start`.
 
-Make sure in [ethlance.db/default-db](https://github.com/madvas/ethlance/blob/master/src/cljs/ethlance/db.cljs) you have following configuration:
+Make sure in [ethlance.db/default-db](https://github.com/madvas/ethlance/blob/master/src/cljs/ethlance/db.cljs) you have the following configuration:
 ```clojure
 :load-node-addresses? true
 :node-url "http://localhost:8549"
 ```
-Visit [localhost:6229](http://localhost:6229/) on browser without MetaMask. I use Chrome Incognito window. 
+Visit [localhost:6229](http://localhost:6229/) in your browser without MetaMask. I use the Chrome Incognito window. 
 
-To redeploy all smart contracts, run following in REPL.
-After you see in browser console all contracts have been deployed, refresh the page.
+To redeploy all smart contracts, run the following in REPL.
 ```clojure
 (in-ns 'ethlance.events)
 (dispatch [:reinitialize])
 ```
+After you see in browser console all contracts have been deployed, refresh the page.
+
 To redeploy only single or few specific smart contracts run:
 ```clojure
 ;; Redeploys and hot swaps EthlanceUser smart contract. No need to refresh page.

--- a/ethlance.el
+++ b/ethlance.el
@@ -1,0 +1,82 @@
+;;;; Usage: ensure ethlance.el is on your load-path
+;;;; i.e: M-: (add-to-list 'load-path "/path/to/ethlance/checkout")
+;;;; then require ethlance `M-x load-library ethlance`
+;;;;
+;;;; (once): customize ethlance-root
+;;;; M-x customize-variable ethlance-root
+;;;; Set to same path as checkout dir above
+;;;;
+;;;; Add to Emacs init:
+;;;; (add-to-list 'load-path "/path/to/ethlance/checkout")
+;;;; (load-library "ethlance")
+;;;;
+;;;; use M-x ethlance-jack-in to jack-in a Clojure and ClojureScript REPL
+;;;;     M-x ethlance-start to start auto-compiling Solidity and testrpc
+;;;;     M-x ethlance-quit to quit all processes
+
+
+(defcustom ethlance-root
+  "/please/set/ethlance-root"
+  "The root directory of the Ethlance repo.")
+
+(defun start-compile-solidity-auto ()
+  (start-process-shell-command "compile-solidity"
+                               "compile-solidity"
+                               (concat "cd " ethlance-root " && " "lein auto compile-solidity")))
+(defun start-testrpc ()
+  (message "Start testrpc")
+  (start-process-shell-command "testrpc"
+                               "testrpc"
+                               (concat "cd " ethlance-root " && "  "lein start-testrpc")))
+
+(defun stop-compile-solidity-auto ()
+  (message "Stop autocompiling Solidity Smart Contracts")
+  (when-let ((buf (get-buffer "compile-solidity")))
+    (kill-buffer buf)))
+
+(defun stop-testrpc ()
+  (message "Stop testrpc")
+  (when-let ((buf (get-buffer "testrpc")))
+    (kill-buffer buf)))
+
+(defun quit-cider (repl-buffer)
+  (set-buffer repl-buffer)
+  ;; essence of cider-interaction.el
+  (cider--quit-connection (cider-current-connection))
+  (unless (cider-connected-p)
+    (cider-close-ancillary-buffers))
+  (message (format "Quit %s" (car p))))
+
+(defun ethlance-jack-in* ()
+  (message "Jack in REPL")
+  (find-file (concat ethlance-root "/project.clj"))
+  (cider-jack-in-clojurescript))
+
+(defun ethlance-jack-in ()
+  (interactive)
+  (ethlance-jack-in*))
+
+(defun ethlance-start ()
+  (interactive)
+  (message "Autocompile Solidity Smart Contracts")
+  (start-compile-solidity-auto)
+  (start-testrpc))
+
+(defun ethlance-stop ()
+  (interactive)
+  (stop-compile-solidity-auto)
+  (stop-testrpc))
+
+(defun ethlance-project-repl (&optional cljs-repl)
+  (get-buffer (concat "*cider-repl " (when cljs-repl "CLJS ") "ethlance*")))
+
+(defun ethlance-quit ()
+  (interactive)
+  (stop-compile-solidity-auto)
+  (stop-testrpc)
+  (when-let ((repl-buffer (ethlance-project-repl)))
+    (quit-cider repl-buffer))
+  (when-let ((cljs-repl-buffer (ethlance-project-repl t)))
+    (quit-cider cljs-repl-buffer)))
+
+(provide 'ethlance)

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,8 @@
   :auto {"compile-solidity" {:file-pattern #"\.(sol)$"
                              :paths ["resources/public/contracts/src"]}}
 
-  :aliases {"compile-solidity" ["shell" "./compile-solidity.sh"]}
+  :aliases {"compile-solidity" ["shell" "./compile-solidity.sh"]
+            "start-testrpc" ["shell" "./start-testrpc.sh"]}
 
   :less {:source-paths ["resources/public/less"]
          :target-path "resources/public/css"
@@ -73,8 +74,7 @@
                 :source-map-timestamp true
                 :preloads [print.foo.preloads.devtools]
                 :closure-defines {goog.DEBUG true}
-                :external-config {:devtools/config {:features-to-install :all}}
-                }}
+                :external-config {:devtools/config {:features-to-install :all}}}}
 
     {:id "min"
      :source-paths ["src/cljs"]

--- a/start-testrpc.sh
+++ b/start-testrpc.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+testrpc --port 8549


### PR DESCRIPTION
By running `ethlance-jack-in` and `ethlance-start` Ethlance can be start from within Emacs.

I also made some spelling changes to the README.