### PR TITLE
add data to ipfs through server

### DIFF
--- a/server/src/ethlance/server/graphql/server.cljs
+++ b/server/src/ethlance/server/graphql/server.cljs
@@ -45,7 +45,7 @@
 
         ;; NOTE: the order off how we are applying middlewares matter
         app (doto (express)
-              (.use (.json body-parser))
+              (.use (.json body-parser #js {:limit "2mb"}))
               (.use middlewares/current-user-express-middleware))
 
         server (new ApolloServer

--- a/shared/src/ethlance/shared/graphql/schema.cljs
+++ b/shared/src/ethlance/shared/graphql/schema.cljs
@@ -194,6 +194,7 @@
     replayEvents: Boolean!,
     githubSignUp(input: githubSignUpInput!): githubSignUpPayload!
     linkedinSignUp(input: linkedinSignUpInput!): linkedinSignUpPayload!
+    uploadData(data: String!): ID!
   }
 
   # mutation result types

--- a/ui/src/ethlance/ui/effects.cljs
+++ b/ui/src/ethlance/ui/effects.cljs
@@ -1,6 +1,8 @@
 (ns ethlance.ui.effects
   (:require
     [cljs-web3.core :as web3]
+    [district.ui.graphql.events :as gql-events]
+    [ethlance.ui.events]
     [re-frame.core :as re]))
 
 
@@ -16,3 +18,12 @@
                   (if err
                     (re/dispatch (conj on-error err))
                     (re/dispatch (conj on-success (aget result "result"))))))))
+
+
+(re/reg-fx
+  :data/upload
+  (fn [{:keys [:data :on-success :on-error]}]
+    (re/dispatch [::gql-events/mutation
+                  {:queries [[:upload-data {:data (if (string? data) data (pr-str data))}]]
+                   :on-success [:ethlance/data-upload-success on-success]
+                   :on-error on-error}])))

--- a/ui/src/ethlance/ui/events.cljs
+++ b/ui/src/ethlance/ui/events.cljs
@@ -57,3 +57,8 @@
         [:page.invoices/initialize-page]
         [:page.new-invoice/initialize-page]]
        :dispatch-later [{:ms 1000 :dispatch [::listen-account-changes]}]})))
+
+(re/reg-event-fx
+  :ethlance/data-upload-success
+  (fn [_ [_ on-success result]]
+    {:dispatch (conj on-success {:Hash (:upload-data result)})}))

--- a/ui/src/ethlance/ui/page/invoices/events.cljs
+++ b/ui/src/ethlance/ui/page/invoices/events.cljs
@@ -32,10 +32,9 @@
 (re/reg-event-fx
   :page.invoices/pay
   (fn [_ [_ invoice]]
-    {:ipfs/call {:func "add"
-                 :args [(js/Blob. [invoice])]
-                 :on-success [::invoice-to-ipfs-success invoice]
-                 :on-error [::invoice-to-ipfs-failure invoice]}}))
+    {:data/upload {:data invoice
+                   :on-success [::invoice-to-ipfs-success invoice]
+                   :on-error [::invoice-to-ipfs-failure invoice]}}))
 
 
 (re/reg-event-fx

--- a/ui/src/ethlance/ui/page/job_contract/events.cljs
+++ b/ui/src/ethlance/ui/page/job_contract/events.cljs
@@ -144,10 +144,9 @@
                       :job-story/id job-story-id
                       :invoice/id invoice-id}]
     {:fx [[:dispatch [::set-buttons-disabled true]]]
-     :ipfs/call {:func "add"
-                 :args [(js/Blob. [ipfs-dispute])]
-                 :on-success [:page.job-contract/raise-dispute-to-ipfs-success ipfs-dispute]
-                 :on-error [::dispute-to-ipfs-failure invoice-id]}}))
+     :data/upload {:data ipfs-dispute
+                   :on-success [:page.job-contract/raise-dispute-to-ipfs-success ipfs-dispute]
+                   :on-error [::dispute-to-ipfs-failure invoice-id]}}))
 
 
 (re/reg-event-fx
@@ -186,10 +185,9 @@
                    :message/creator (:employer proposal-data)
                    :text (:text proposal-data)}]
       {:fx [[:dispatch [::set-buttons-disabled true]]]
-       :ipfs/call {:func "add"
-                   :args [(js/Blob. [to-ipfs])]
-                   :on-success [:accept-proposal-to-ipfs-success to-ipfs]
-                   :on-error [::accept-proposal-to-ipfs-failure to-ipfs]}})))
+       :data/upload {:data to-ipfs
+                     :on-success [:accept-proposal-to-ipfs-success to-ipfs]
+                     :on-error [::accept-proposal-to-ipfs-failure to-ipfs]}})))
 
 
 (re/reg-event-fx
@@ -273,10 +271,9 @@
                       :job/id job-id
                       :job-story/id job-story-id
                       :invoice/id invoice-id}]
-    {:ipfs/call {:func "add"
-                 :args [(js/Blob. [ipfs-dispute])]
-                 :on-success [:page.job-contract/resolve-dispute-to-ipfs-success event]
-                 :on-error [::dispute-to-ipfs-failure event]}}))
+    {:data/upload {:data ipfs-dispute
+                   :on-success [:page.job-contract/resolve-dispute-to-ipfs-success event]
+                   :on-error [::dispute-to-ipfs-failure event]}}))
 
 
 (defn send-resolve-dispute-tx

--- a/ui/src/ethlance/ui/page/job_detail/events.cljs
+++ b/ui/src/ethlance/ui/page/job_detail/events.cljs
@@ -216,10 +216,9 @@
                                        :job-arbiter/fee
                                        :job-arbiter/fee-currency-id])]
     {:fx [[:dispatch [::set-arbiter-tx-in-progress true]]]
-     :ipfs/call {:func "add"
-                 :args [(js/Blob. [ipfs-arbitration])]
-                 :on-success [:page.job-detail/arbitration-to-ipfs-success event]
-                 :on-error [::arbitration-to-ipfs-failed]}}))
+     :data/upload {:data ipfs-arbitration
+                   :on-success [:page.job-detail/arbitration-to-ipfs-success event]
+                   :on-error [::arbitration-to-ipfs-failed]}}))
 
 
 (re/reg-event-fx

--- a/ui/src/ethlance/ui/page/new_invoice/events.cljs
+++ b/ui/src/ethlance/ui/page/new_invoice/events.cljs
@@ -102,11 +102,10 @@
                         :message/text (:message db-invoice)
                         :job/id (-> db-invoice :invoiced-job :job/id)
                         :job-story/id (-> db-invoice :invoiced-job :job-story/id parse-int)}]
-      {:fx [[:dispatch [::set-tx-in-progress true]]
-            [:ipfs/call {:func "add"
-                         :args [(js/Blob. [ipfs-invoice])]
-                         :on-success [::invoice-to-ipfs-success ipfs-invoice]
-                         :on-error [::invoice-to-ipfs-failure ipfs-invoice]}]]})))
+      {:fx [[:dispatch [::set-tx-in-progress true]]]
+       :data/upload {:data ipfs-invoice
+                     :on-success [::invoice-to-ipfs-success ipfs-invoice]
+                     :on-error [::invoice-to-ipfs-failure ipfs-invoice]}})))
 
 
 (re/reg-event-fx

--- a/ui/src/ethlance/ui/page/new_job/events.cljs
+++ b/ui/src/ethlance/ui/page/new_job/events.cljs
@@ -206,10 +206,9 @@
   (fn [{:keys [db]}]
     (let [db-job (get db state-key)
           ipfs-job (reduce-kv (partial db-job->ipfs-job db-job) {} db->ipfs-mapping)]
-      {:fx [[:ipfs/call {:func "add"
-                         :args [(js/Blob. [ipfs-job])]
-                         :on-success [::job-to-ipfs-success]
-                         :on-error [::job-to-ipfs-failure]}]]})))
+      {:data/upload {:data ipfs-job
+                     :on-success [::job-to-ipfs-success]
+                     :on-error [::job-to-ipfs-failure]}})))
 
 
 (re/reg-event-fx

--- a/ui/src/ethlance/ui/page/profile/events.cljs
+++ b/ui/src/ethlance/ui/page/profile/events.cljs
@@ -55,10 +55,9 @@
                            :job/id (get-in invitation-data [:job :job/id])
                            :message/creator (:employer invitation-data)
                            :text (:text invitation-data)}]
-      {:ipfs/call {:func "add"
-                   :args [(js/Blob. [ipfs-invitation])]
-                   :on-success [:invitation-to-ipfs-success ipfs-invitation]
-                   :on-error [:invitation-to-ipfs-failure ipfs-invitation]}})))
+      {:data/upload {:data ipfs-invitation
+                     :on-success [:invitation-to-ipfs-success ipfs-invitation]
+                     :on-error [:invitation-to-ipfs-failure ipfs-invitation]}})))
 
 
 (re/reg-event-fx

--- a/ui/src/ethlance/ui/page/sign_up/events.cljs
+++ b/ui/src/ethlance/ui/page/sign_up/events.cljs
@@ -161,10 +161,9 @@
   :page.sign-up/upload-user-image
   [interceptors]
   (fn [_ [{:keys [:file-info] :as data}]]
-    {:ipfs/call {:func "add"
-                 :args [(:file file-info)]
-                 :on-success [::upload-user-image-success data]
-                 :on-error [::logging/error "Error uploading user image" {:data data}]}}))
+    {:data/upload {:data (-> file-info :selected-file :url-data)
+                   :on-success [::upload-user-image-success data]
+                   :on-error [::logging/error "Error uploading user image" {:data data}]}}))
 
 
 (re/reg-event-fx


### PR DESCRIPTION
To avoid exposing credentials to the used IPFS service, files are not added directly to IPFS directly from the UI (browser), but they are send to the server and it uploads the file to IPFS on users' behalf.