### PR TITLE
disable pm2-logrotate

### DIFF
--- a/docker-builds/server/Dockerfile
+++ b/docker-builds/server/Dockerfile
@@ -52,7 +52,6 @@ WORKDIR ${ETHLANCE_SERVER_ROOT}
 COPY --from=builder /build /build
 # Initialize events log
 RUN echo -n "{:last-processed-block 27409455}" > ethlance-events.log
-RUN npx pm2 install pm2-logrotate
 
 EXPOSE 6300
 CMD ["npx", "pm2-runtime", "out/ethlance_server.js"]


### PR DESCRIPTION
logs rotation are directly managed by the docker container, we don't need to use pm2-logrotate module